### PR TITLE
fix

### DIFF
--- a/src/app/[locale]/[type]/[...slug]/page.tsx
+++ b/src/app/[locale]/[type]/[...slug]/page.tsx
@@ -13,13 +13,15 @@ import { PageNavigation } from '@/components/layout/PageNavigation'
 import { MainTitle, SubTitle } from '@/components/blocks/HeadingBlock'
 import { SEO } from '@/components/layout/SEO'
 import { NotFound } from '@/components/layout/NotFound'
-import { TextToSpeech } from '@/components/tts/TextToSpeech'
 import { getAkiradocsConfig } from "@/lib/getAkiradocsConfig";
 import { getTranslation } from '@/lib/staticTranslation';
 import { ClientSideControls } from '@/components/layout/ClientSideControl';
 import { Metadata } from 'next'
 
-// export const runtime = 'edge'
+// Enable edge runtime
+export const runtime = 'edge';
+
+// Keep force-static to ensure pages are statically generated at build time
 export const dynamic = 'force-static';
 
 const PostContainer = ({ children }: { children: React.ReactNode }) => (


### PR DESCRIPTION
# Enable Edge Runtime for Static Pages

- **Purpose:**
 Update the page configuration to utilize edge runtime for improved performance.
- **Key Changes:**
  - Enabled edge runtime by uncommenting the relevant line.
  - Ensured pages are statically generated at build time with `dynamic = 'force-static'`.
  - Removed the import of `TextToSpeech`, indicating potential feature removal or refactor.
- **Impact:**
 This change is expected to enhance page load speed and optimize resource usage.

> ✨ Generated with love by [Kaizen](https://cloudcode.ai) ❤️


<details>
<summary>Original Description</summary>
None
</details>

