### PR TITLE
fix: updated deploy step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,18 +24,19 @@ jobs:
           cache-dependency-path: package-lock.json
           
       - name: Install dependencies
-        working-directory: ./
         run: npm ci
-        
+
       - name: Build
-        working-directory: ./
+        env:
+          NEXT_PUBLIC_BASE_PATH: ''
         run: |
           npm run build
+          npx @cloudflare/next-on-pages@1
         
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:
-          path: .next/static
+          path: ./.vercel/output/static
 
   deploy:
     needs: build


### PR DESCRIPTION
# Deploy Workflow Improvements

- **Purpose:**
 Update the GitHub Actions workflow to improve the build and deployment process.
- **Key Changes:**
  - Removed the `working-directory` configuration from the `Install dependencies` and `Build` steps, as the default working directory is already the repository root.
  - Added an environment variable `NEXT_PUBLIC_BASE_PATH` set to an empty string to ensure the correct asset paths during the build process.
  - Replaced the `npm run build` command with a two-step process: first, run the standard `npm run build` command, then use the `@cloudflare/next-on-pages` tool to prepare the output for Vercel deployment.
  - Updated the `Upload artifact` step to use the correct output directory `./.vercel/output/static` instead of `.next/static`.
- **Impact:**
 These changes should improve the reliability and consistency of the deployment workflow, ensuring the correct asset paths and preparing the output for the Vercel platform.

> ✨ Generated with love by [Kaizen](https://cloudcode.ai) ❤️


<details>
<summary>Original Description</summary>
None
</details>

